### PR TITLE
Add flag to  override the occi location hostname.

### DIFF
--- a/api/registry.py
+++ b/api/registry.py
@@ -27,6 +27,8 @@ from api.compute import openstack
 
 from api.extensions import occi_future
 
+from nova.flags import FLAGS
+
 
 class OCCIRegistry(occi_registry.NonePersistentRegistry):
     """
@@ -36,6 +38,11 @@ class OCCIRegistry(occi_registry.NonePersistentRegistry):
     def __init__(self):
         super(OCCIRegistry, self).__init__()
         self.transient = {}
+
+    def set_hostname(self, hostname):
+        if FLAGS.occi_custom_location_hostname:
+            hostname = FLAGS.occi_custom_location_hostname
+        super(OCCIRegistry, self).set_hostname(hostname)
 
     def get_extras(self, extras):
         """

--- a/api/wsgi.py
+++ b/api/wsgi.py
@@ -64,7 +64,11 @@ OCCI_OPTS = [
                         help="The network manager to use with the OCCI API."),
              cfg.IntOpt("occiapi_listen_port",
                         default=8787,
-                        help="Port OCCI interface will listen on.")
+                        help="Port OCCI interface will listen on."),
+             cfg.StrOpt("occi_custom_location_hostname",
+                        default=None,
+                        help="Override OCCI location hostname with custom value")
+
              ]
 
 FLAGS = flags.FLAGS


### PR DESCRIPTION
If the OCCI WSGI server is running behind a proxy, the location is
incorrectly set. This flags allows to override the hostname of the
location with a custom value.

Note that although the name is "hostname" (from pyssf) the correct value
for that field is something like http://myocciserver.example.org:PORT
