### PR TITLE
Set the hostname to None rather than 'None' (string)

### DIFF
--- a/nova_glue/vm.py
+++ b/nova_glue/vm.py
@@ -56,7 +56,7 @@ def create_vm(entity, context):
     if 'occi.compute.hostname' in entity.attributes:
         name = entity.attributes['occi.compute.hostname']
     else:
-        name = 'None'
+        name = None
     key_name = key_data = None
     password = utils.generate_password(FLAGS.password_length)
     access_ip_v4 = None


### PR DESCRIPTION
Hi Thijs,

it would be nice if you could integrate this. That way, nova will create a hostname following the configured pattern.

I tested it with our installation and now the server name is again generated rather than set to 'None'.

Cheers,
Björn
