### PR TITLE
Fix term names according to specification.

### DIFF
--- a/occi_os_api/wsgi.py
+++ b/occi_os_api/wsgi.py
@@ -176,7 +176,7 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
                 continue
 
             os_template = os_mixins.OsTemplate(
-                                term=self._transformTerm(img['name']),
+                                term=img['id'],
                                 scheme=template_schema,
                                 os_id=img['id'],
                                 related=[infrastructure.OS_TEMPLATE],
@@ -201,7 +201,7 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
 
         for itype in os_flavours:
             resource_template = os_mixins.ResourceTemplate(
-                term=self._transformTerm(itype),
+                term=itype,
                 scheme=template_schema,
                 related=[infrastructure.RESOURCE_TEMPLATE],
                 title='This is an openstack ' + itype + ' flavor.',
@@ -236,7 +236,7 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
         for group in groups:
             if group['name'] not in excld_grps:
                 sec_mix = os_mixins.UserSecurityGroupMixin(
-                term=self._transformTerm(group['name']),
+                term=str(group["id"]),  # NOTE(aloga): group.id is a long
                 scheme=sec_grp,
                 related=[os_addon.SEC_GROUP],
                 attributes=None,
@@ -246,9 +246,3 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
                     self.registry.get_backend(sec_mix, extras)
                 except AttributeError:
                     self.register_backend(sec_mix, MIXIN_BACKEND)
-
-    def _transformTerm(self, term):
-        """
-        Transform a term to be compliant with the spec.
-        """
-        return term.strip().replace(' ', '_').replace('(', '_').replace(')', '_').replace('.', '_').lower()


### PR DESCRIPTION
This should closes #38. Now I get:
- Secgroup:
  Category: 38; scheme="http://schemas.openstack.org/infrastructure/security/group#"; (...)
- Image:
  Category: 3ef6bb0c-6a17-47c9-a949-70256eb6651e; scheme="http://schemas.openstack.org/template/os# (...)
- Flavor:
  Category: m1.medium; scheme="http://schemas.openstack.org/template/resource#" (...)

Is this enough?
