### PR TITLE
Import the vnc_enabled option into our FLAGS object.

### DIFF
--- a/occi_os_api/nova_glue/vm.py
+++ b/occi_os_api/nova_glue/vm.py
@@ -47,6 +47,9 @@ VOLUME_API = volume.API()
 
 LOG = logging.getLogger(__name__)
 
+# NOTE(aloga): we need to import the option
+FLAGS.import_opt('vnc_enabled', 'nova.vnc')
+
 
 def create_vm(entity, context):
     """


### PR DESCRIPTION
The VNC module is not imported anywhere (it just defines some options that are then used by the compute drivers) so we need to import the option into our FLAGS object.
