### PR TITLE
Fix term names according to specification.

### DIFF
--- a/occi_os_api/backends/compute.py
+++ b/occi_os_api/backends/compute.py
@@ -118,8 +118,8 @@ class ComputeBackend(KindBackend, ActionBackend):
 
         mixin = new.mixins[0]
         if isinstance(mixin, os_mixins.ResourceTemplate):
-            flavor_name = mixin.term
-            vm.resize_vm(uid, flavor_name, context)
+            flavor_id = mixin.term
+            vm.resize_vm(uid, flavor_id, context)
             old.attributes['occi.compute.state'] = 'inactive'
             # now update the mixin info
             old.mixins.append(mixin)

--- a/occi_os_api/backends/openstack.py
+++ b/occi_os_api/backends/openstack.py
@@ -108,7 +108,6 @@ class SecurityGroupBackend(backend.UserDefinedMixinBackend):
         """
         context = extras['nova_ctx']
         security_group = security.retrieve_group(category.term,
-                                                 extras['nova_ctx'].project_id,
                                                  extras['nova_ctx'])
         security.remove_group(security_group.id, context)
 
@@ -127,8 +126,7 @@ class SecurityRuleBackend(backend.KindBackend):
         sec_mixin = get_sec_mixin(entity)
         context = extras['nova_ctx']
         security_group = security.retrieve_group(sec_mixin.term,
-                                                 extras['nova_ctx']
-                                                 .project_id, context)
+                                                 context)
         sg_rule = make_sec_rule(entity, security_group['id'])
 
         if security_group_rule_exists(security_group, sg_rule):

--- a/occi_os_api/nova_glue/security.py
+++ b/occi_os_api/nova_glue/security.py
@@ -73,18 +73,16 @@ def remove_group(group_id, context):
         raise AttributeError(error)
 
 
-def retrieve_group(mixin_term, project_id, context):
+def retrieve_group(mixin_term, context):
     """
     Retrieve the security group associated with the security mixin.
 
     mixin_term -- The term of the mixin representing the group.
-    project_id -- The project id.
     context -- The os context.
     """
     try:
-        sec_group = db.security_group_get_by_name(context,
-                                                  project_id,
-                                                  mixin_term)
+        sec_group = db.security_group_get(context,
+                                          mixin_term)
     except Exception:
         # ensure that an OpenStack sec group matches the mixin
         # if not, create one.

--- a/occi_os_api/registry.py
+++ b/occi_os_api/registry.py
@@ -297,13 +297,13 @@ class OCCIRegistry(occi_registry.NonePersistentRegistry):
         result.append(entity)
 
         # 2. os and res templates
-        flavor_name = instance['instance_type'].name
-        res_tmp = self.get_category('/' + flavor_name + '/', extras)
+        flavor_id = instance['instance_type'].flavorid
+        res_tmp = self.get_category('/' + flavor_id + '/', extras)
         entity.mixins.append(res_tmp)
 
         os_id = instance['image_ref']
-        image_name = storage.get_image(os_id, context)['name']
-        os_tmp = self.get_category('/' + image_name + '/', extras)
+        image_id = storage.get_image(os_id, context)['id']
+        os_tmp = self.get_category('/' + image_id + '/', extras)
         entity.mixins.append(os_tmp)
 
         # 3. network links & get links from cache!

--- a/occi_os_api/wsgi.py
+++ b/occi_os_api/wsgi.py
@@ -176,14 +176,14 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
                 continue
 
             os_template = os_mixins.OsTemplate(
-                                term=self._transformTerm(img['name']),
+                                term=img['id'],
                                 scheme=template_schema,
                                 os_id=img['id'],
                                 related=[infrastructure.OS_TEMPLATE],
                                 attributes=None,
                                 title='This is an OS ' + img['name'] + \
                                                             ' VM image',
-                                location='/' + quote(img['name']) + '/')
+                                location='/' + quote(img['id']) + '/')
 
             try:
                 self.registry.get_backend(os_template, extras)
@@ -199,13 +199,13 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
         template_schema = 'http://schemas.openstack.org/template/resource#'
         os_flavours = instance_types.get_all_types()
 
-        for itype in os_flavours:
+        for itype in os_flavours.values():
             resource_template = os_mixins.ResourceTemplate(
-                term=self._transformTerm(itype),
+                term=itype["flavorid"],
                 scheme=template_schema,
                 related=[infrastructure.RESOURCE_TEMPLATE],
-                title='This is an openstack ' + itype + ' flavor.',
-                location='/' + quote(itype) + '/')
+                title='This is an openstack ' + itype["name"] + ' flavor.',
+                location='/' + quote(itype["flavorid"]) + '/')
 
             try:
                 self.registry.get_backend(resource_template, extras)
@@ -236,19 +236,13 @@ class OCCIApplication(occi_wsgi.Application, wsgi.Application):
         for group in groups:
             if group['name'] not in excld_grps:
                 sec_mix = os_mixins.UserSecurityGroupMixin(
-                term=self._transformTerm(group['name']),
+                term=str(group["id"]),  # NOTE(aloga): group.id is a long
                 scheme=sec_grp,
                 related=[os_addon.SEC_GROUP],
                 attributes=None,
                 title=group['name'],
-                location='/security/' + quote(group['name']) + '/')
+                location='/security/' + quote(str(group['id'])) + '/')
                 try:
                     self.registry.get_backend(sec_mix, extras)
                 except AttributeError:
                     self.register_backend(sec_mix, MIXIN_BACKEND)
-
-    def _transformTerm(self, term):
-        """
-        Transform a term to be compliant with the spec.
-        """
-        return term.strip().replace(' ', '_').replace('(', '_').replace(')', '_').replace('.', '_').lower()


### PR DESCRIPTION
Since now the images, flavor and secgroups categories and links are
based on the ID, we have to adapt all the code to reflect this change.

Closes #38
