### PR TITLE
Pass the project_id as a kwarg to the API.

### DIFF
--- a/occi_os_api/nova_glue/net.py
+++ b/occi_os_api/nova_glue/net.py
@@ -86,6 +86,8 @@ def add_floating_ip(uid, pool_name, context):
 
     # FIXME: currently quantum driver has a notimplemented here :-(
     # fixed_ips = NETWORK_API.get_fixed_ip(uid, context)
+    # NOTE(aloga): nova-network is still suported in Grizzly, so we
+    # should not drop support for it.
     tmp = NETWORK_API.get_instance_nw_info(context, vm_instance)[0]
     fixed_ip = tmp.fixed_ips()[0]['address']
 

--- a/occi_os_api/nova_glue/security.py
+++ b/occi_os_api/nova_glue/security.py
@@ -64,7 +64,7 @@ def retrieve_groups_by_project(context):
 
     context -- The os context.
     """
-    return SEC_API.list(context, context.project_id)
+    return SEC_API.list(context, project=context.project_id)
 
 
 def create_rule(name, iden, rule, context):


### PR DESCRIPTION
Fixes SecurityGroupNotFoundForProject exception.
