### PR TITLE
Fix suspend/start behavior

### DIFF
--- a/occi_os_api/nova_glue/vm.py
+++ b/occi_os_api/nova_glue/vm.py
@@ -244,7 +244,18 @@ def start_vm(uid, context):
     """
     instance = get_vm(uid, context)
     try:
-        COMPUTE_API.resume(context, instance)
+        if instance['vm_state'] in [vm_states.PAUSED]:
+            COMPUTE_API.unpause(context, instance)
+        elif instance['vm_state'] in [vm_states.SUSPENDED]:
+            COMPUTE_API.resume(context, instance)
+        # the following will probably not happen, as COMPUTE_API.stop()
+        # is never called.
+        elif instance['vm_state'] in [vm_states.STOPPED]:
+            COMPUTE_API.start(context, instance)
+        else:
+            raise exceptions.HTTPError(500, "Unable to map start to appropriate OS action.")
+    except exceptions.HTTPError as e:
+        raise e
     except Exception as e:
         raise AttributeError(e.message)
 

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -263,6 +263,34 @@ class SystemTest(unittest.TestCase):
             else:
                 time.sleep(5)
 
+        # trigger suspend
+        trigger_action(self.token, vm_location + '?action=suspend',
+                       'suspend; scheme="http://schemas.ogf.org/occi/'
+                       'infrastructure/compute/action#"')
+
+        # wait
+        cont = False
+        while not cont:
+            if 'occi.compute.state="inactive"' in \
+                    get_node(self.token, vm_location)['x-occi-attribute']:
+                cont = True
+            else:
+                time.sleep(5)
+
+        # trigger start
+        trigger_action(self.token, vm_location + '?action=start',
+                       'start; scheme="http://schemas.ogf.org/occi/'
+                       'infrastructure/compute/action#"')
+
+        # wait
+        cont = False
+        while not cont:
+            if 'occi.compute.state="active"' in \
+                    get_node(self.token, vm_location)['x-occi-attribute']:
+                cont = True
+            else:
+                time.sleep(5)
+
         # delete
         destroy_node(self.token, vm_location)
 


### PR DESCRIPTION
Fixes #77

OCCI.stop() is mapped to OS.suspend() and
OCCI.suspend() is mapped to OS.pause()

Both OCCI operations are inverted by OCCI.start(), which consequently
has to distinguish the current machine state to trigger the correct
inverse OS operation, i.e. OS.resume() or OS.unpause.
