### PR TITLE
Added instruction to register OCCI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ Make sure the API (name from above) is enabled in `nova.conf`:
 	[...]
 	enabled_apis=ec2,occiapi,osapi_compute,osapi_volume,metadata
 	[...]
+
+#### Register service in keystone
+You can register the OCCI service endpoint in Keyston via the following commands. First you need to create the OCCI service via
+
+	$ keystone service-create --name nova --type occi --description 'Nova OCCI Service'
+	+-------------+----------------------------------+
+	|   Property  |              Value               |
+	+-------------+----------------------------------+
+	| description |           OCCI service           |
+	|      id     | 8e6de5d0d7624584bed6bec9bef7c9e0 |
+	|     name    |               nova               |
+	|     type    |               occi               |
+	+-------------+----------------------------------+
+
+from which you get the new service ID and use it to register the OCCI endpoint in Keystone:
+
+	$ keystone endpoint-create --service_id 8e6de5d0d7624584bed6bec9bef7c9e0 --region RegionOne --publicurl http://$HOSTNAME:8787/ --internalurl  http://$HOSTNAME:8787/ --adminurl http://$HOSTNAME:8787/
 	
 #### Hacking the port number
 


### PR DESCRIPTION
To complete the instruction set, I added instructions on how to register the OCCI Nova-api endpoint into keystone. This is a step needed if we want to correctly get teh endpoints information from BDII, but it is in general a good practice after the installation of the egg
